### PR TITLE
Change the way new tasks are handled

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -23,7 +23,7 @@ h4,
 h5,
 h6,
 header {
-  font-family: "Zilla Slab", Arial, sans-serif;
+  font-family: "Zilla Slab", Helvetica, sans-serif;
   letter-spacing: 0.05em;
 }
 </style>

--- a/src/components/DayOrganizer.vue
+++ b/src/components/DayOrganizer.vue
@@ -55,6 +55,7 @@ main {
 import Vue from "vue";
 import Component from "vue-class-component";
 import { Prop } from "vue-property-decorator";
+import { namespace } from "vuex-class";
 
 import { TaskData } from "@/types";
 
@@ -63,11 +64,18 @@ import Task from "@/components/Task.vue";
 @Component({ components: { Task } })
 export default class DayOrganizer extends Vue {
   @Prop() private dateModifier!: number;
-  private tasks!: TaskData[];
   private newTask: TaskData | null = null;
 
-  created() {
-    this.tasks = this.$store.getters.getTasksByDate(this.date);
+  get tasks() {
+    if (this.dateModifier === 0) {
+      return this.$store.getters.getTodaysTasks;
+    } else if (this.dateModifier === 1) {
+      return this.$store.getters.getTomorrowsTasks;
+    } else if (this.dateModifier === 2) {
+      return this.$store.getters.getNextDaysTasks;
+    } else {
+      return [];
+    }
   }
 
   get date() {
@@ -101,13 +109,7 @@ export default class DayOrganizer extends Vue {
   private closeNewTask() {
     this.$nextTick(() => {
       this.newTask = null;
-      this.refreshTasks();
     });
-  }
-
-  private refreshTasks() {
-    this.tasks = this.$store.getters.getTasksByDate(this.date);
-    this.$forceUpdate();
   }
 }
 </script>

--- a/src/components/DayOrganizer.vue
+++ b/src/components/DayOrganizer.vue
@@ -8,7 +8,7 @@
       <Task v-for="(task, index) in tasks" :details="task" :key="index"></Task>
       <div>
         <button @click="createNewTask()" v-if="newTask === null">+ New Task</button>
-        <Task v-else :details="newTask" @description-added="closeNewTask"></Task>
+        <Task v-else :details="newTask" @description-blurred="closeNewTask"></Task>
       </div>
     </main>
   </section>

--- a/src/components/DayOrganizer.vue
+++ b/src/components/DayOrganizer.vue
@@ -6,10 +6,8 @@
 
     <main>
       <Task v-for="(task, index) in tasks" :details="task" :key="index"></Task>
-      <div>
-        <button @click="createNewTask()" v-if="newTask === null">+ New Task</button>
-        <Task v-else :details="newTask" @description-blurred="closeNewTask"></Task>
-      </div>
+      <button @click="createNewTask()" v-if="newTask === null">+ New Task</button>
+      <Task v-else :details="newTask" @description-blurred="closeNewTask"></Task>
     </main>
   </section>
 </template>

--- a/src/components/DayOrganizer.vue
+++ b/src/components/DayOrganizer.vue
@@ -2,10 +2,14 @@
   <section class="day">
     <header>
       <span class="name">{{name}}</span>
-      <button @click="addTask">+</button>
     </header>
+
     <main>
       <Task v-for="(task, index) in tasks" :details="task" :key="index"></Task>
+      <div>
+        <button @click="createNewTask()" v-if="newTask === null">+ New Task</button>
+        <Task v-else :details="newTask"></Task>
+      </div>
     </main>
   </section>
 </template>
@@ -30,19 +34,20 @@ header {
   .name {
     flex-grow: 1;
   }
-
-  button {
-    background-color: transparent;
-    border: none;
-    color: rgba(255, 255, 255, 0.9);
-    font-family: "Work Sans";
-    font-size: 28px;
-  }
 }
 
 main {
   padding: 5px 0;
-  // border-left: 1px solid #009086;
+
+  button {
+    padding: 5px 10px;
+    background-color: #e5e5e5;
+    border: none;
+    color: #006fc0;
+    font-size: 16px;
+    font-weight: 800;
+    font-family: "Work Sans", Arial, sans-serif;
+  }
 }
 </style>
 
@@ -59,6 +64,7 @@ import Task from "@/components/Task.vue";
 export default class DayOrganizer extends Vue {
   @Prop() private dateModifier!: number;
   private tasks!: TaskData[];
+  private newTask: TaskData | null = null;
 
   created() {
     this.tasks = this.$store.getters.getTasksByDate(this.date);
@@ -82,9 +88,14 @@ export default class DayOrganizer extends Vue {
     }
   }
 
-  private addTask() {
-    this.$store.commit("addTask", { date: this.date, order: this.tasks.length });
-    this.refreshTasks();
+  private createNewTask() {
+    this.newTask = {
+      id: undefined,
+      description: "",
+      date: this.date,
+      order: -1,
+      done: false
+    };
   }
 
   private refreshTasks() {

--- a/src/components/DayOrganizer.vue
+++ b/src/components/DayOrganizer.vue
@@ -8,7 +8,7 @@
       <Task v-for="(task, index) in tasks" :details="task" :key="index"></Task>
       <div>
         <button @click="createNewTask()" v-if="newTask === null">+ New Task</button>
-        <Task v-else :details="newTask"></Task>
+        <Task v-else :details="newTask" @description-added="closeNewTask"></Task>
       </div>
     </main>
   </section>
@@ -93,9 +93,16 @@ export default class DayOrganizer extends Vue {
       id: undefined,
       description: "",
       date: this.date,
-      order: -1,
+      order: this.tasks[this.tasks.length - 1].order + 1,
       done: false
     };
+  }
+
+  private closeNewTask() {
+    this.$nextTick(() => {
+      this.newTask = null;
+      this.refreshTasks();
+    });
   }
 
   private refreshTasks() {

--- a/src/components/DayOrganizer.vue
+++ b/src/components/DayOrganizer.vue
@@ -93,7 +93,7 @@ export default class DayOrganizer extends Vue {
       id: undefined,
       description: "",
       date: this.date,
-      order: this.tasks[this.tasks.length - 1].order + 1,
+      order: this.tasks.length > 0 ? this.tasks[this.tasks.length - 1].order + 1 : 0,
       done: false
     };
   }

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -75,6 +75,9 @@ export default class Task extends Vue {
 
   private mounted() {
     this.onDescriptionChanged();
+    if (this.details.id === undefined) {
+      (this.$refs.description as HTMLElement).focus();
+    }
   }
 
   private updated() {

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -7,7 +7,7 @@
       :disabled="details.done" 
       ref="description"
       rows="1"
-      @input="onDescriptionChanged()"
+      @input="onDescriptionInput()"
     ></textarea>
     <input type="checkbox" class="checkbox" v-model="details.done" v-show="details.description !== ''">
   </div>
@@ -66,15 +66,8 @@ import { TaskData } from "@/types";
 export default class Task extends Vue {
   @Prop() private details!: TaskData;
 
-  @Watch("details.description")
-  private onDescriptionChanged() {
-    const descriptionElement = this.$refs.description as HTMLElement;
-    descriptionElement.style.height = "auto"; // behavioral fix
-    descriptionElement.style.height = descriptionElement.scrollHeight - 10 + "px";
-  }
-
   private mounted() {
-    this.onDescriptionChanged();
+    this.onDescriptionInput();
     if (this.details.id === undefined) {
       (this.$refs.description as HTMLElement).focus();
     }
@@ -82,6 +75,19 @@ export default class Task extends Vue {
 
   private updated() {
     this.$store.commit("updateTask", this.details);
+  }
+
+  private onDescriptionInput() {
+    const descriptionElement = this.$refs.description as HTMLElement;
+    descriptionElement.style.height = "auto"; // behavioral fix
+    descriptionElement.style.height = descriptionElement.scrollHeight - 10 + "px";
+  }
+
+  @Watch("details.description")
+  private onDescriptionChanged(newDescription: string, oldDescription: string) {
+    if (oldDescription === "" && newDescription !== "") {
+      this.$emit("description-added");
+    }
   }
 }
 </script>

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -8,6 +8,7 @@
       ref="description"
       rows="1"
       @input="onDescriptionInput()"
+      @blur="onDescriptionBlurred()"
     ></textarea>
     <input type="checkbox" class="checkbox" v-model="details.done" v-show="details.description !== ''">
   </div>
@@ -83,11 +84,8 @@ export default class Task extends Vue {
     descriptionElement.style.height = descriptionElement.scrollHeight - 10 + "px";
   }
 
-  @Watch("details.description")
-  private onDescriptionChanged(newDescription: string, oldDescription: string) {
-    if (oldDescription === "" && newDescription !== "") {
-      this.$emit("description-added");
-    }
+  private onDescriptionBlurred(newDescription: string, oldDescription: string) {
+    this.$emit("description-blurred");
   }
 }
 </script>

--- a/src/store.ts
+++ b/src/store.ts
@@ -24,7 +24,6 @@ const state: RootState = {
 };
 
 const getTasksByDate = (state_: RootState, date: Date) => {
-  console.log(state_.tasks.filter((task: TaskData) => task.date.toDateString() === date.toDateString()));
   return state_.tasks.filter((task: TaskData) => task.date.toDateString() === date.toDateString()).sort((a, b) => {
     if (a.order > b.order) {
       return 1;

--- a/src/store.ts
+++ b/src/store.ts
@@ -23,17 +23,36 @@ const state: RootState = {
   ]
 };
 
+const getTasksByDate = (state_: RootState, date: Date) => {
+  console.log(state_.tasks.filter((task: TaskData) => task.date.toDateString() === date.toDateString()));
+  return state_.tasks.filter((task: TaskData) => task.date.toDateString() === date.toDateString()).sort((a, b) => {
+    if (a.order > b.order) {
+      return 1;
+    } else if (a.order < b.order) {
+      return -1;
+    } else {
+      return 0;
+    }
+  });
+};
+
 const getters = {
   getTasksByDate: (state_: RootState) => (date: Date) => {
-    return state_.tasks.filter((task: TaskData) => task.date.toDateString() === date.toDateString()).sort((a, b) => {
-      if (a.order > b.order) {
-        return 1;
-      } else if (a.order < b.order) {
-        return -1;
-      } else {
-        return 0;
-      }
-    });
+    return getTasksByDate(state_, date);
+  },
+  getTodaysTasks: (state_: RootState) => {
+    let date = new Date(Date.now());
+    return getTasksByDate(state_, date);
+  },
+  getTomorrowsTasks: (state_: RootState) => {
+    let date = new Date(Date.now());
+    date.setDate(date.getDate() + 1);
+    return getTasksByDate(state_, date);
+  },
+  getNextDaysTasks: (state_: RootState) => {
+    let date = new Date(Date.now());
+    date.setDate(date.getDate() + 2);
+    return getTasksByDate(state_, date);
   }
 };
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -38,21 +38,14 @@ const getters = {
 };
 
 const mutations = {
-  addTask(state_: RootState, payload: any) {
-    const newTask: TaskData = {
-      id: window.performance.now(),
-      description: "",
-      date: payload.date,
-      order: payload.order,
-      done: false
-    };
-
-    state_.tasks.push(newTask);
-    return newTask;
-  },
   updateTask(state_: RootState, updatedTask: TaskData) {
-    let storedTask = state_.tasks.find((task) => task.id === updatedTask.id);
-    storedTask = { ...storedTask, ...updatedTask };
+    if (updatedTask.id === undefined) {
+      updatedTask.id = window.performance.now() + Math.random();
+      state_.tasks.push(updatedTask);
+    } else {
+      let storedTask = state_.tasks.find((task) => task.id === updatedTask.id);
+      storedTask = { ...storedTask, ...updatedTask };
+    }
   }
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export interface TaskData {
-  id: number;
+  id?: number;
   description: string;
   date: Date;
   order: number;


### PR DESCRIPTION
Move responsibility for creating new tasks from DayPlanner.vue to Task.vue. Dayplanner merely exposes the UI.